### PR TITLE
rename XxxClass.XxxClassBuilder to XxxClass.Builder

### DIFF
--- a/a2a4j-core/src/main/java/io/github/a2ap/core/jsonrpc/JSONRPCError.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/jsonrpc/JSONRPCError.java
@@ -93,8 +93,8 @@ public class JSONRPCError {
         this.data = data;
     }
 
-    public static JSONRPCErrorBuilder builder() {
-        return new JSONRPCErrorBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public int getCode() {
@@ -144,7 +144,7 @@ public class JSONRPCError {
     /**
      * Builder for creating instances of JSONRPCError.
      */
-    public static class JSONRPCErrorBuilder {
+    public static class Builder {
 
         private int code;
 
@@ -152,20 +152,20 @@ public class JSONRPCError {
 
         private Object data;
 
-        JSONRPCErrorBuilder() {
+        Builder() {
         }
 
-        public JSONRPCErrorBuilder code(int code) {
+        public Builder code(int code) {
             this.code = code;
             return this;
         }
 
-        public JSONRPCErrorBuilder message(String message) {
+        public Builder message(String message) {
             this.message = message;
             return this;
         }
 
-        public JSONRPCErrorBuilder data(Object data) {
+        public Builder data(Object data) {
             this.data = data;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/jsonrpc/JSONRPCRequest.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/jsonrpc/JSONRPCRequest.java
@@ -83,8 +83,8 @@ public class JSONRPCRequest {
         this.id = id;
     }
 
-    public static JSONRPCRequestBuilder builder() {
-        return new JSONRPCRequestBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getJsonrpc() {
@@ -140,7 +140,7 @@ public class JSONRPCRequest {
     /**
      * Builder class for JSONRPCRequest.
      */
-    public static class JSONRPCRequestBuilder {
+    public static class Builder {
 
         private String method;
 
@@ -148,20 +148,20 @@ public class JSONRPCRequest {
 
         private String id;
 
-        JSONRPCRequestBuilder() {
+        Builder() {
         }
 
-        public JSONRPCRequestBuilder method(String method) {
+        public Builder method(String method) {
             this.method = method;
             return this;
         }
 
-        public JSONRPCRequestBuilder params(Object params) {
+        public Builder params(Object params) {
             this.params = params;
             return this;
         }
 
-        public JSONRPCRequestBuilder id(String id) {
+        public Builder id(String id) {
             this.id = id;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentAuthentication.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentAuthentication.java
@@ -48,8 +48,8 @@ public class AgentAuthentication {
         this.credentials = credentials;
     }
 
-    public static AgentAuthenticationBuilder builder() {
-        return new AgentAuthenticationBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public List<String> getSchemes() {
@@ -91,21 +91,21 @@ public class AgentAuthentication {
     /**
      * Builder class for AgentAuthentication.
      */
-    public static class AgentAuthenticationBuilder {
+    public static class Builder {
 
         private List<String> schemes;
 
         private String credentials;
 
-        AgentAuthenticationBuilder() {
+        Builder() {
         }
 
-        public AgentAuthenticationBuilder schemes(List<String> schemes) {
+        public Builder schemes(List<String> schemes) {
             this.schemes = schemes;
             return this;
         }
 
-        public AgentAuthenticationBuilder credentials(String credentials) {
+        public Builder credentials(String credentials) {
             this.credentials = credentials;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentCapabilities.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentCapabilities.java
@@ -50,8 +50,8 @@ public class AgentCapabilities {
         this.stateTransitionHistory = stateTransitionHistory;
     }
 
-    public static AgentCapabilitiesBuilder builder() {
-        return new AgentCapabilitiesBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public boolean isStreaming() {
@@ -103,7 +103,7 @@ public class AgentCapabilities {
     /**
      * Builder for {@link AgentCapabilities}
      */
-    public static class AgentCapabilitiesBuilder {
+    public static class Builder {
 
         private boolean streaming = false;
 
@@ -111,20 +111,20 @@ public class AgentCapabilities {
 
         private boolean stateTransitionHistory = false;
 
-        AgentCapabilitiesBuilder() {
+        Builder() {
         }
 
-        public AgentCapabilitiesBuilder streaming(boolean streaming) {
+        public Builder streaming(boolean streaming) {
             this.streaming = streaming;
             return this;
         }
 
-        public AgentCapabilitiesBuilder pushNotifications(boolean pushNotifications) {
+        public Builder pushNotifications(boolean pushNotifications) {
             this.pushNotifications = pushNotifications;
             return this;
         }
 
-        public AgentCapabilitiesBuilder stateTransitionHistory(boolean stateTransitionHistory) {
+        public Builder stateTransitionHistory(boolean stateTransitionHistory) {
             this.stateTransitionHistory = stateTransitionHistory;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentCard.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentCard.java
@@ -129,8 +129,8 @@ public class AgentCard {
         this.skills = skills;
     }
 
-    public static AgentCardBuilder builder() {
-        return new AgentCardBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getId() {
@@ -284,7 +284,7 @@ public class AgentCard {
     /**
      * Builder class for creating instances of {@link AgentCard}.
      */
-    public static class AgentCardBuilder {
+    public static class Builder {
 
         private String id;
 
@@ -314,75 +314,75 @@ public class AgentCard {
 
         private List<AgentSkill> skills;
 
-        AgentCardBuilder() {
+        Builder() {
         }
 
-        public AgentCardBuilder id(String id) {
+        public Builder id(String id) {
             this.id = id;
             return this;
         }
 
-        public AgentCardBuilder name(String name) {
+        public Builder name(String name) {
             this.name = name;
             return this;
         }
 
-        public AgentCardBuilder description(String description) {
+        public Builder description(String description) {
             this.description = description;
             return this;
         }
 
-        public AgentCardBuilder url(String url) {
+        public Builder url(String url) {
             this.url = url;
             return this;
         }
 
-        public AgentCardBuilder provider(AgentProvider provider) {
+        public Builder provider(AgentProvider provider) {
             this.provider = provider;
             return this;
         }
 
-        public AgentCardBuilder version(String version) {
+        public Builder version(String version) {
             this.version = version;
             return this;
         }
 
-        public AgentCardBuilder documentationUrl(String documentationUrl) {
+        public Builder documentationUrl(String documentationUrl) {
             this.documentationUrl = documentationUrl;
             return this;
         }
 
-        public AgentCardBuilder capabilities(AgentCapabilities capabilities) {
+        public Builder capabilities(AgentCapabilities capabilities) {
             this.capabilities = capabilities;
             return this;
         }
 
-        public AgentCardBuilder authentication(AgentAuthentication authentication) {
+        public Builder authentication(AgentAuthentication authentication) {
             this.authentication = authentication;
             return this;
         }
 
-        public AgentCardBuilder securitySchemes(Map<String, SecurityScheme> securitySchemes) {
+        public Builder securitySchemes(Map<String, SecurityScheme> securitySchemes) {
             this.securitySchemes = securitySchemes;
             return this;
         }
 
-        public AgentCardBuilder security(List<Map<String, List<String>>> security) {
+        public Builder security(List<Map<String, List<String>>> security) {
             this.security = security;
             return this;
         }
 
-        public AgentCardBuilder defaultInputModes(List<String> defaultInputModes) {
+        public Builder defaultInputModes(List<String> defaultInputModes) {
             this.defaultInputModes = defaultInputModes;
             return this;
         }
 
-        public AgentCardBuilder defaultOutputModes(List<String> defaultOutputModes) {
+        public Builder defaultOutputModes(List<String> defaultOutputModes) {
             this.defaultOutputModes = defaultOutputModes;
             return this;
         }
 
-        public AgentCardBuilder skills(List<AgentSkill> skills) {
+        public Builder skills(List<AgentSkill> skills) {
             this.skills = skills;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentProvider.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentProvider.java
@@ -46,8 +46,8 @@ public class AgentProvider {
         this.url = url;
     }
 
-    public static AgentProviderBuilder builder() {
-        return new AgentProviderBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getOrganization() {
@@ -89,21 +89,21 @@ public class AgentProvider {
     /**
      * Builder for creating instances of {@link AgentProvider}.
      */
-    public static class AgentProviderBuilder {
+    public static class Builder {
 
         private String organization;
 
         private String url;
 
-        AgentProviderBuilder() {
+        Builder() {
         }
 
-        public AgentProviderBuilder organization(String organization) {
+        public Builder organization(String organization) {
             this.organization = organization;
             return this;
         }
 
-        public AgentProviderBuilder url(String url) {
+        public Builder url(String url) {
             this.url = url;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentSkill.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/AgentSkill.java
@@ -87,8 +87,8 @@ public class AgentSkill {
         this.outputModes = outputModes;
     }
 
-    public static AgentSkillBuilder builder() {
-        return new AgentSkillBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getId() {
@@ -175,7 +175,7 @@ public class AgentSkill {
     /**
      * Builder for {@link AgentSkill}
      */
-    public static class AgentSkillBuilder {
+    public static class Builder {
 
         private String id;
 
@@ -191,40 +191,40 @@ public class AgentSkill {
 
         private List<String> outputModes;
 
-        AgentSkillBuilder() {
+        Builder() {
         }
 
-        public AgentSkillBuilder id(String id) {
+        public Builder id(String id) {
             this.id = id;
             return this;
         }
 
-        public AgentSkillBuilder name(String name) {
+        public Builder name(String name) {
             this.name = name;
             return this;
         }
 
-        public AgentSkillBuilder description(String description) {
+        public Builder description(String description) {
             this.description = description;
             return this;
         }
 
-        public AgentSkillBuilder tags(List<String> tags) {
+        public Builder tags(List<String> tags) {
             this.tags = tags;
             return this;
         }
 
-        public AgentSkillBuilder examples(List<String> examples) {
+        public Builder examples(List<String> examples) {
             this.examples = examples;
             return this;
         }
 
-        public AgentSkillBuilder inputModes(List<String> inputModes) {
+        public Builder inputModes(List<String> inputModes) {
             this.inputModes = inputModes;
             return this;
         }
 
-        public AgentSkillBuilder outputModes(List<String> outputModes) {
+        public Builder outputModes(List<String> outputModes) {
             this.outputModes = outputModes;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/Artifact.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/Artifact.java
@@ -92,8 +92,8 @@ public class Artifact implements TaskUpdate {
         this.metadata = metadata;
     }
 
-    public static ArtifactBuilder builder() {
-        return new ArtifactBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getArtifactId() {
@@ -162,7 +162,7 @@ public class Artifact implements TaskUpdate {
     /**
      * Builder for creating instances of {@link Artifact}.
      */
-    public static class ArtifactBuilder {
+    public static class Builder {
 
         private String artifactId;
 
@@ -174,30 +174,30 @@ public class Artifact implements TaskUpdate {
 
         private Map<String, Object> metadata;
 
-        ArtifactBuilder() {
+        Builder() {
         }
 
-        public ArtifactBuilder artifactId(String artifactId) {
+        public Builder artifactId(String artifactId) {
             this.artifactId = artifactId;
             return this;
         }
 
-        public ArtifactBuilder name(String name) {
+        public Builder name(String name) {
             this.name = name;
             return this;
         }
 
-        public ArtifactBuilder description(String description) {
+        public Builder description(String description) {
             this.description = description;
             return this;
         }
 
-        public ArtifactBuilder parts(List<Part> parts) {
+        public Builder parts(List<Part> parts) {
             this.parts = parts;
             return this;
         }
 
-        public ArtifactBuilder metadata(Map<String, Object> metadata) {
+        public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/Message.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/Message.java
@@ -87,8 +87,8 @@ public class Message implements SendMessageResponse, SendStreamingMessageRespons
         this.kind = kind;
     }
 
-    public static MessageBuilder builder() {
-        return new MessageBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getMessageId() {
@@ -175,7 +175,7 @@ public class Message implements SendMessageResponse, SendStreamingMessageRespons
     /**
      * Builder class for Message.
      */
-    public static class MessageBuilder {
+    public static class Builder {
 
         private String messageId;
 
@@ -191,40 +191,40 @@ public class Message implements SendMessageResponse, SendStreamingMessageRespons
 
         private String kind;
 
-        MessageBuilder() {
+        Builder() {
         }
 
-        public MessageBuilder messageId(String messageId) {
+        public Builder messageId(String messageId) {
             this.messageId = messageId;
             return this;
         }
 
-        public MessageBuilder taskId(String taskId) {
+        public Builder taskId(String taskId) {
             this.taskId = taskId;
             return this;
         }
 
-        public MessageBuilder contextId(String contextId) {
+        public Builder contextId(String contextId) {
             this.contextId = contextId;
             return this;
         }
 
-        public MessageBuilder role(String role) {
+        public Builder role(String role) {
             this.role = role;
             return this;
         }
 
-        public MessageBuilder parts(List<Part> parts) {
+        public Builder parts(List<Part> parts) {
             this.parts = parts;
             return this;
         }
 
-        public MessageBuilder metadata(Map<String, Object> metadata) {
+        public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;
             return this;
         }
 
-        public MessageBuilder kind(String kind) {
+        public Builder kind(String kind) {
             this.kind = kind;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/MessageSendConfiguration.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/MessageSendConfiguration.java
@@ -58,8 +58,8 @@ public class MessageSendConfiguration {
         this.blocking = blocking;
     }
 
-    public static MessageSendConfigurationBuilder builder() {
-        return new MessageSendConfigurationBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public List<String> getAcceptedOutputModes() {
@@ -121,7 +121,7 @@ public class MessageSendConfiguration {
     /**
      * Builder class for MessageSendConfiguration.
      */
-    public static class MessageSendConfigurationBuilder {
+    public static class Builder {
 
         private List<String> acceptedOutputModes;
 
@@ -131,25 +131,25 @@ public class MessageSendConfiguration {
 
         private Boolean blocking;
 
-        MessageSendConfigurationBuilder() {
+        Builder() {
         }
 
-        public MessageSendConfigurationBuilder acceptedOutputModes(List<String> acceptedOutputModes) {
+        public Builder acceptedOutputModes(List<String> acceptedOutputModes) {
             this.acceptedOutputModes = acceptedOutputModes;
             return this;
         }
 
-        public MessageSendConfigurationBuilder historyLength(Integer historyLength) {
+        public Builder historyLength(Integer historyLength) {
             this.historyLength = historyLength;
             return this;
         }
 
-        public MessageSendConfigurationBuilder pushNotificationConfig(PushNotificationConfig pushNotificationConfig) {
+        public Builder pushNotificationConfig(PushNotificationConfig pushNotificationConfig) {
             this.pushNotificationConfig = pushNotificationConfig;
             return this;
         }
 
-        public MessageSendConfigurationBuilder blocking(Boolean blocking) {
+        public Builder blocking(Boolean blocking) {
             this.blocking = blocking;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/MessageSendParams.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/MessageSendParams.java
@@ -53,8 +53,8 @@ public class MessageSendParams {
         this.metadata = metadata;
     }
 
-    public static MessageSendParamsBuilder builder() {
-        return new MessageSendParamsBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public Message getMessage() {
@@ -106,7 +106,7 @@ public class MessageSendParams {
     /**
      * Builder for creating instances of {@link MessageSendParams}.
      */
-    public static class MessageSendParamsBuilder {
+    public static class Builder {
 
         private Message message;
 
@@ -114,20 +114,20 @@ public class MessageSendParams {
 
         private Map<String, Object> metadata;
 
-        MessageSendParamsBuilder() {
+        Builder() {
         }
 
-        public MessageSendParamsBuilder message(Message message) {
+        public Builder message(Message message) {
             this.message = message;
             return this;
         }
 
-        public MessageSendParamsBuilder configuration(MessageSendConfiguration configuration) {
+        public Builder configuration(MessageSendConfiguration configuration) {
             this.configuration = configuration;
             return this;
         }
 
-        public MessageSendParamsBuilder metadata(Map<String, Object> metadata) {
+        public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/PushNotificationConfig.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/PushNotificationConfig.java
@@ -47,8 +47,8 @@ public class PushNotificationConfig {
         this.authToken = authToken;
     }
 
-    public static PushNotificationConfigBuilder builder() {
-        return new PushNotificationConfigBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getUrl() {
@@ -90,21 +90,21 @@ public class PushNotificationConfig {
     /**
      * Builder class for PushNotificationConfig.
      */
-    public static class PushNotificationConfigBuilder {
+    public static class Builder {
 
         private String url;
 
         private String authToken;
 
-        PushNotificationConfigBuilder() {
+        Builder() {
         }
 
-        public PushNotificationConfigBuilder url(String url) {
+        public Builder url(String url) {
             this.url = url;
             return this;
         }
 
-        public PushNotificationConfigBuilder authToken(String authToken) {
+        public Builder authToken(String authToken) {
             this.authToken = authToken;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/RequestContext.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/RequestContext.java
@@ -85,8 +85,8 @@ public class RequestContext {
         this.relatedTasks = relatedTasks;
     }
 
-    public static RequestContextBuilder builder() {
-        return new RequestContextBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getTaskId() {
@@ -155,7 +155,7 @@ public class RequestContext {
     /**
      * Builder for creating instances of RequestContext.
      */
-    public static class RequestContextBuilder {
+    public static class Builder {
 
         private String taskId;
 
@@ -167,30 +167,30 @@ public class RequestContext {
 
         private List<Task> relatedTasks;
 
-        RequestContextBuilder() {
+        Builder() {
         }
 
-        public RequestContextBuilder taskId(String taskId) {
+        public Builder taskId(String taskId) {
             this.taskId = taskId;
             return this;
         }
 
-        public RequestContextBuilder contextId(String contextId) {
+        public Builder contextId(String contextId) {
             this.contextId = contextId;
             return this;
         }
 
-        public RequestContextBuilder request(MessageSendParams request) {
+        public Builder request(MessageSendParams request) {
             this.request = request;
             return this;
         }
 
-        public RequestContextBuilder task(Task task) {
+        public Builder task(Task task) {
             this.task = task;
             return this;
         }
 
-        public RequestContextBuilder relatedTasks(List<Task> relatedTasks) {
+        public Builder relatedTasks(List<Task> relatedTasks) {
             this.relatedTasks = relatedTasks;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/SecurityScheme.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/SecurityScheme.java
@@ -68,8 +68,8 @@ public class SecurityScheme {
         this.bearerFormat = bearerFormat;
     }
 
-    public static SecuritySchemeBuilder builder() {
-        return new SecuritySchemeBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getType() {
@@ -147,7 +147,7 @@ public class SecurityScheme {
     /**
      * Builder for creating instances of SecurityScheme.
      */
-    public static class SecuritySchemeBuilder {
+    public static class Builder {
 
         private String type;
 
@@ -161,35 +161,35 @@ public class SecurityScheme {
 
         private String bearerFormat;
 
-        SecuritySchemeBuilder() {
+        Builder() {
         }
 
-        public SecuritySchemeBuilder type(String type) {
+        public Builder type(String type) {
             this.type = type;
             return this;
         }
 
-        public SecuritySchemeBuilder scheme(String scheme) {
+        public Builder scheme(String scheme) {
             this.scheme = scheme;
             return this;
         }
 
-        public SecuritySchemeBuilder name(String name) {
+        public Builder name(String name) {
             this.name = name;
             return this;
         }
 
-        public SecuritySchemeBuilder in(String in) {
+        public Builder in(String in) {
             this.in = in;
             return this;
         }
 
-        public SecuritySchemeBuilder description(String description) {
+        public Builder description(String description) {
             this.description = description;
             return this;
         }
 
-        public SecuritySchemeBuilder bearerFormat(String bearerFormat) {
+        public Builder bearerFormat(String bearerFormat) {
             this.bearerFormat = bearerFormat;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/Task.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/Task.java
@@ -80,8 +80,8 @@ public class Task implements SendMessageResponse, SendStreamingMessageResponse {
         this.metadata = metadata;
     }
 
-    public static TaskBuilder builder() {
-        return new TaskBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String getId() {
@@ -158,7 +158,7 @@ public class Task implements SendMessageResponse, SendStreamingMessageResponse {
     /**
      * Builder for creating instances of Task.
      */
-    public static class TaskBuilder {
+    public static class Builder {
 
         private String id;
 
@@ -172,35 +172,35 @@ public class Task implements SendMessageResponse, SendStreamingMessageResponse {
 
         private Map<String, Object> metadata;
 
-        TaskBuilder() {
+        Builder() {
         }
 
-        public TaskBuilder id(String id) {
+        public Builder id(String id) {
             this.id = id;
             return this;
         }
 
-        public TaskBuilder contextId(String contextId) {
+        public Builder contextId(String contextId) {
             this.contextId = contextId;
             return this;
         }
 
-        public TaskBuilder status(TaskStatus status) {
+        public Builder status(TaskStatus status) {
             this.status = status;
             return this;
         }
 
-        public TaskBuilder artifacts(List<Artifact> artifacts) {
+        public Builder artifacts(List<Artifact> artifacts) {
             this.artifacts = artifacts;
             return this;
         }
 
-        public TaskBuilder history(List<Message> history) {
+        public Builder history(List<Message> history) {
             this.history = history;
             return this;
         }
 
-        public TaskBuilder metadata(Map<String, Object> metadata) {
+        public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/TaskPushNotificationConfig.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/TaskPushNotificationConfig.java
@@ -74,14 +74,14 @@ public class TaskPushNotificationConfig extends PushNotificationConfig {
                 + ", authToken='" + getAuthToken() + '\'' + '}';
     }
 
-    public static TaskPushNotificationConfigBuilder taskPushBuilder() {
-        return new TaskPushNotificationConfigBuilder();
+    public static Builder taskPushBuilder() {
+        return new Builder();
     }
 
     /**
      * Builder for creating instances of TaskPushNotificationConfig.
      */
-    public static class TaskPushNotificationConfigBuilder {
+    public static class Builder {
 
         private String url;
 
@@ -89,20 +89,20 @@ public class TaskPushNotificationConfig extends PushNotificationConfig {
 
         private String taskId;
 
-        TaskPushNotificationConfigBuilder() {
+        Builder() {
         }
 
-        public TaskPushNotificationConfigBuilder url(String url) {
+        public Builder url(String url) {
             this.url = url;
             return this;
         }
 
-        public TaskPushNotificationConfigBuilder authToken(String authToken) {
+        public Builder authToken(String authToken) {
             this.authToken = authToken;
             return this;
         }
 
-        public TaskPushNotificationConfigBuilder taskId(String taskId) {
+        public Builder taskId(String taskId) {
             this.taskId = taskId;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/TaskStatus.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/TaskStatus.java
@@ -71,8 +71,8 @@ public class TaskStatus implements TaskUpdate {
         this.error = error;
     }
 
-    public static TaskStatusBuilder builder() {
-        return new TaskStatusBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     public TaskState getState() {
@@ -132,7 +132,7 @@ public class TaskStatus implements TaskUpdate {
     /**
      * Builder for creating instances of TaskStatus.
      */
-    public static class TaskStatusBuilder {
+    public static class Builder {
 
         private TaskState state;
 
@@ -142,25 +142,25 @@ public class TaskStatus implements TaskUpdate {
 
         private String error;
 
-        TaskStatusBuilder() {
+        Builder() {
         }
 
-        public TaskStatusBuilder state(TaskState state) {
+        public Builder state(TaskState state) {
             this.state = state;
             return this;
         }
 
-        public TaskStatusBuilder message(Message message) {
+        public Builder message(Message message) {
             this.message = message;
             return this;
         }
 
-        public TaskStatusBuilder timestamp(String timestamp) {
+        public Builder timestamp(String timestamp) {
             this.timestamp = timestamp;
             return this;
         }
 
-        public TaskStatusBuilder error(String error) {
+        public Builder error(String error) {
             this.error = error;
             return this;
         }

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/server/impl/InMemoryTaskManager.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/server/impl/InMemoryTaskManager.java
@@ -70,7 +70,7 @@ public class InMemoryTaskManager implements TaskManager {
         taskId = taskId == null ? UUID.randomUUID().toString() : taskId;
         String contextId = params.getMessage().getContextId();
         contextId = contextId == null ? UUID.randomUUID().toString() : contextId;
-        RequestContext.RequestContextBuilder contextBuilder = RequestContext.builder()
+        RequestContext.Builder contextBuilder = RequestContext.builder()
                 .taskId(taskId).contextId(contextId).request(params);
         Task currentTask = taskStore.load(taskId);
         if (currentTask == null) {

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/util/JsonUtil.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/util/JsonUtil.java
@@ -115,8 +115,6 @@ public final class JsonUtil {
      * @param jsonStr json string
      * @return true if the string is a json string
      */
-
-
     public static boolean isJsonStr(String jsonStr) {
         if (jsonStr == null || jsonStr.trim().isEmpty()) {
             return false;


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->


## Checklist

- [x]  I have read the [Contributing Guide](https://github.com/a2ap/a2a4j/blob/main/CONTRIBUTING.md)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Any Else Note

This PR mainly changes some of the Builder class names. The Builder classes in the project are static inner classes, but the naming convention retains the name of the outer class, for example: `io.github.a2ap.core.jsonrpc.JSONRPCRequest.JSONRPCRequestBuilder`.

I believe `XxxClass.Builder` is better than `XxxClass.XxxClassBuilder`, as it offers certain benefits in terms of code readability and user usage. Of course, this is a point for discussion, and I welcome sharing ideas.
