### PR TITLE
feature: naming consistency

### DIFF
--- a/a2a4j-core/src/main/java/io/github/a2ap/core/client/A2AClient.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/client/A2AClient.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Flux;
  * Interface defining the core functionality of an A2A client.
  * The A2A client is responsible for interacting with an A2A server.
  */
-public interface A2aClient {
+public interface A2AClient {
 
     /**
      * Get the AgentCard info current in client

--- a/a2a4j-core/src/main/java/io/github/a2ap/core/client/impl/DefaultA2AClient.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/client/impl/DefaultA2AClient.java
@@ -16,7 +16,7 @@
 
 package io.github.a2ap.core.client.impl;
 
-import io.github.a2ap.core.client.A2aClient;
+import io.github.a2ap.core.client.A2AClient;
 import io.github.a2ap.core.client.CardResolver;
 import io.github.a2ap.core.jsonrpc.JSONRPCRequest;
 import io.github.a2ap.core.jsonrpc.JSONRPCResponse;
@@ -41,8 +41,8 @@ import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
 /**
- * Default implementation of the A2aClient interface providing comprehensive A2A protocol client functionality.
- * 
+ * Default implementation of the A2AClient interface providing comprehensive A2A protocol client functionality.
+ *
  * This implementation offers a complete HTTP-based client for interacting with A2A protocol-compliant
  * agents. It handles all aspects of the client-side A2A communication including agent discovery,
  * task management, streaming operations, and push notification configuration.
@@ -77,10 +77,10 @@ import reactor.netty.http.client.HttpClient;
  * Thread safety: This implementation is thread-safe and can be used concurrently
  * across multiple threads.
  */
-public class DefaultA2aClient implements A2aClient {
+public class DefaultA2AClient implements A2AClient {
 
-    private static final Logger log = LoggerFactory.getLogger(DefaultA2aClient.class);
-    
+    private static final Logger log = LoggerFactory.getLogger(DefaultA2AClient.class);
+
     private AgentCard agentCard;
     
     private final CardResolver cardResolver;
@@ -92,7 +92,7 @@ public class DefaultA2aClient implements A2aClient {
      * 
      * @param cardResolver The CardResolver to use for resolving agent cards.
      */
-    public DefaultA2aClient(CardResolver cardResolver) {
+    public DefaultA2AClient(CardResolver cardResolver) {
         this.cardResolver = cardResolver;
         this.agentCard = this.retrieveAgentCard();
         this.client = HttpClient.create().baseUrl(this.agentCard.getUrl());
@@ -102,7 +102,7 @@ public class DefaultA2aClient implements A2aClient {
      * Constructs a new A2aClient with the agent card info
      * @param agentCard agent card info
      */
-    public DefaultA2aClient(AgentCard agentCard) {
+    public DefaultA2AClient(AgentCard agentCard) {
         this.agentCard = agentCard;
         this.client = HttpClient.create().baseUrl(this.agentCard.getUrl());
         this.cardResolver = null;
@@ -114,7 +114,7 @@ public class DefaultA2aClient implements A2aClient {
      * @param cardResolver The CardResolver to use for resolving agent cards.
      * @param agentCard The agent card info.
      */
-    public DefaultA2aClient(AgentCard agentCard, CardResolver cardResolver) {
+    public DefaultA2AClient(AgentCard agentCard, CardResolver cardResolver) {
         this.agentCard = agentCard;
         this.cardResolver = cardResolver;
         this.client = HttpClient.create().baseUrl(this.agentCard.getUrl());

--- a/a2a4j-samples/server-hello-world/README.md
+++ b/a2a4j-samples/server-hello-world/README.md
@@ -289,8 +289,8 @@ curl -X POST http://localhost:8089/a2a/server \
 
 ### Core Components
 
-- **`A2aServerApplication`**: Spring Boot main application class, configures CORS and application startup
-- **`A2aServerController`**: REST controller implementing A2A protocol endpoints
+- **`A2AServerApplication`**: Spring Boot main application class, configures CORS and application startup
+- **`A2AServerController`**: REST controller implementing A2A protocol endpoints
 - **`DemoAgentExecutor`**: Sample agent executor demonstrating various event types and artifact generation
 
 ### Execution Flow

--- a/a2a4j-samples/server-hello-world/README_CN.md
+++ b/a2a4j-samples/server-hello-world/README_CN.md
@@ -389,8 +389,8 @@ curl -X POST http://localhost:8089/a2a/server \
 
 ### 核心组件
 
-- **`A2aServerApplication`**: Spring Boot 主应用类，配置 CORS 和应用启动
-- **`A2aServerController`**: REST 控制器，实现 A2A 协议端点
+- **`A2AServerApplication`**: Spring Boot 主应用类，配置 CORS 和应用启动
+- **`A2AServerController`**: REST 控制器，实现 A2A 协议端点
 - **`DemoAgentExecutor`**: 示例智能体执行器，展示各种事件类型和工件生成
 
 ### 执行流程

--- a/a2a4j-samples/server-hello-world/src/main/java/io/github/a2ap/server/hello/world/A2AServerApplication.java
+++ b/a2a4j-samples/server-hello-world/src/main/java/io/github/a2ap/server/hello/world/A2AServerApplication.java
@@ -38,7 +38,7 @@ import org.springframework.web.reactive.config.WebFluxConfigurer;
  * The server can be accessed at {@code http://localhost:8089} by default.
  *
  * @see io.github.a2ap.server.hello.world.agent.DemoAgentExecutor
- * @see io.github.a2ap.server.hello.world.controller.A2aServerController
+ * @see io.github.a2ap.server.hello.world.controller.A2AServerController
  */
 
 @SpringBootApplication

--- a/a2a4j-samples/server-hello-world/src/main/java/io/github/a2ap/server/hello/world/controller/A2AServerController.java
+++ b/a2a4j-samples/server-hello-world/src/main/java/io/github/a2ap/server/hello/world/controller/A2AServerController.java
@@ -54,7 +54,7 @@ import reactor.core.publisher.Flux;
  * @see io.github.a2ap.core.model.AgentCard
  */
 @RestController
-public class A2aServerController {
+public class A2AServerController {
 
     private final A2AServer a2aServer;
 
@@ -66,7 +66,7 @@ public class A2aServerController {
      * @param a2aServer   the A2A server instance for accessing agent card
      * @param a2aDispatch the dispatcher for handling JSON-RPC requests
      */
-    public A2aServerController(A2AServer a2aServer, Dispatcher a2aDispatch) {
+    public A2AServerController(A2AServer a2aServer, Dispatcher a2aDispatch) {
         this.a2aServer = a2aServer;
         this.a2aDispatch = a2aDispatch;
     }

--- a/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/STARTER_API.md
+++ b/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/STARTER_API.md
@@ -4,15 +4,15 @@ This document provides specific API reference for the A2A4J Server Spring Boot S
 
 ## Auto-Configuration
 
-### A2aServerAutoConfiguration
+### A2AServerAutoConfiguration
 
 The main auto-configuration class that sets up all A2A server components.
 
 ```java
 @Configuration
-@EnableConfigurationProperties(A2aServerProperties.class)
-@AutoConfigureAfter(value = {A2aServerProperties.class})
-public class A2aServerAutoConfiguration {
+@EnableConfigurationProperties(A2AServerProperties.class)
+@AutoConfigureAfter(value = {A2AServerProperties.class})
+public class A2AServerAutoConfiguration {
     // Auto-configured beans
 }
 ```
@@ -34,13 +34,13 @@ All beans are created with `@ConditionalOnMissingBean`, allowing easy override.
 
 ## Configuration Properties
 
-### A2aServerProperties
+### A2AServerProperties
 
 Configuration properties class for A2A server settings.
 
 ```java
 @ConfigurationProperties(prefix = "a2a.server")
-public class A2aServerProperties {
+public class A2AServerProperties {
     // Configuration properties
 }
 ```
@@ -139,7 +139,7 @@ public class MyCustomAgentExecutor implements AgentExecutor {
 ```java
 @Bean
 @Primary
-public AgentCard enhancedAgentCard(A2aServerProperties properties) {
+public AgentCard enhancedAgentCard(A2AServerProperties properties) {
     return AgentCard.builder()
         .name(properties.getName())
         .description(properties.getDescription())
@@ -383,7 +383,7 @@ The starter provides IDE support through configuration metadata in `spring-confi
   "groups": [
     {
       "name": "a2a.server",
-      "type": "io.github.a2ap.server.spring.auto.configuration.A2aServerProperties",
+      "type": "io.github.a2ap.server.spring.auto.configuration.A2AServerProperties",
       "description": "Configuration properties for A2A Server."
     }
   ],
@@ -411,7 +411,7 @@ Create your own auto-configuration that builds upon the starter:
 
 ```java
 @Configuration
-@AutoConfigureAfter(A2aServerAutoConfiguration.class)
+@AutoConfigureAfter(A2AServerAutoConfiguration.class)
 @ConditionalOnProperty(name = "myapp.a2a.enhanced", havingValue = "true")
 public class EnhancedA2AAutoConfiguration {
     

--- a/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/java/io/github/a2ap/server/spring/auto/configuration/A2AServerAutoConfiguration.java
+++ b/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/java/io/github/a2ap/server/spring/auto/configuration/A2AServerAutoConfiguration.java
@@ -61,13 +61,13 @@ import reactor.core.publisher.Mono;
  * All beans are created with {@link ConditionalOnMissingBean} annotation, allowing users
  * to override any component by providing their own implementation.
  *
- * @see A2aServerProperties
+ * @see A2AServerProperties
  * @see A2AServer
  */
 @Configuration
-@EnableConfigurationProperties(A2aServerProperties.class)
-@AutoConfigureAfter(value = {A2aServerProperties.class})
-public class A2aServerAutoConfiguration {
+@EnableConfigurationProperties(A2AServerProperties.class)
+@AutoConfigureAfter(value = {A2AServerProperties.class})
+public class A2AServerAutoConfiguration {
 
     /**
      * Creates a default in-memory queue manager for managing task event queues. This
@@ -171,7 +171,7 @@ public class A2aServerAutoConfiguration {
      */
     @Bean(name = "a2aServerSelfCard")
     @ConditionalOnMissingBean
-    public AgentCard agentCard(final A2aServerProperties a2aServerProperties) {
+    public AgentCard agentCard(final A2AServerProperties a2aServerProperties) {
         return AgentCard.builder()
                 .name(a2aServerProperties.getName())
                 .url(a2aServerProperties.getUrl())

--- a/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/java/io/github/a2ap/server/spring/auto/configuration/A2AServerProperties.java
+++ b/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/java/io/github/a2ap/server/spring/auto/configuration/A2AServerProperties.java
@@ -46,7 +46,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @see io.github.a2ap.core.model.AgentCapabilities
  */
 @ConfigurationProperties(prefix = "a2a.server")
-public class A2aServerProperties implements Serializable {
+public class A2AServerProperties implements Serializable {
 
     @Serial
     private static final long serialVersionUID = -608274692651491547L;

--- a/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -2,14 +2,14 @@
   "groups": [
     {
       "name": "a2a.server",
-      "type": "io.github.a2ap.core.server.config.A2aServerProperties",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties",
+      "type": "io.github.a2ap.core.server.config.A2AServerProperties",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties",
       "description": "Configuration properties for A2A protocol."
     },
     {
       "name": "a2a.server.capabilities",
-      "type": "io.github.a2ap.core.server.config.A2aServerProperties$Capabilities",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties",
+      "type": "io.github.a2ap.core.server.config.A2AServerProperties$Capabilities",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties",
       "sourceMethod": "getCapabilities()",
       "description": "Agent capabilities configuration."
     }
@@ -18,45 +18,45 @@
     {
       "name": "a2a.server.name",
       "type": "java.lang.String",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties",
       "description": "Agent name."
     },
     {
       "name": "a2a.server.description",
       "type": "java.lang.String",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties",
       "description": "Agent description."
     },
     {
       "name": "a2a.server.version",
       "type": "java.lang.String",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties",
       "description": "Agent version."
     },
     {
       "name": "a2a.server.url",
       "type": "java.lang.String",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties",
       "description": "Agent URL."
     },
     {
       "name": "a2a.server.capabilities.streaming",
       "type": "java.lang.Boolean",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties$Capabilities",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties$Capabilities",
       "defaultValue": true,
       "description": "Whether the agent supports streaming responses."
     },
     {
       "name": "a2a.server.capabilities.push-notifications",
       "type": "java.lang.Boolean",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties$Capabilities",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties$Capabilities",
       "defaultValue": false,
       "description": "Whether the agent supports push notifications."
     },
     {
       "name": "a2a.server.capabilities.state-transition-history",
       "type": "java.lang.Boolean",
-      "sourceType": "io.github.a2ap.core.server.config.A2aServerProperties$Capabilities",
+      "sourceType": "io.github.a2ap.core.server.config.A2AServerProperties$Capabilities",
       "defaultValue": true,
       "description": "Whether the agent supports state transition history."
     }

--- a/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/a2a4j-spring-boot-starter/a2a4j-server-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-io.github.a2ap.server.spring.auto.configuration.A2aServerAutoConfiguration
+io.github.a2ap.server.spring.auto.configuration.A2AServerAutoConfiguration


### PR DESCRIPTION
## What's changed?

naming consistency

- A2aClient -> A2AClient
- DefaultA2aClient -> DefaultA2AClient
- A2aServerAutoConfiguration -> A2AServerAutoConfiguration
- A2aServerProperties -> A2AServerProperties
- A2aServerController -> A2AServerController


## Checklist

- [x]  I have read the [Contributing Guide](https://github.com/a2ap/a2a4j/blob/main/CONTRIBUTING.md)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Any Else Note


