### PR TITLE
[bugfix] ensure the generated data can be returned in time when in multi flux which have dependency

### DIFF
--- a/a2a4j-core/src/main/java/io/github/a2ap/core/server/impl/DefaultA2AServer.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/server/impl/DefaultA2AServer.java
@@ -140,7 +140,7 @@ public class DefaultA2AServer implements A2AServer {
         final EventQueue eventQueue = queueManager.create(taskContext.getTaskId());
 
         // Execute agent and collect final result
-        return agentExecutor.execute(taskContext, eventQueue).thenMany(eventQueue.asFlux().doOnNext(event -> {
+        return Flux.merge(agentExecutor.execute(taskContext, eventQueue).thenMany(Mono.empty()), eventQueue.asFlux().doOnNext(event -> {
             if (event instanceof TaskStatusUpdateEvent) {
                 taskManager.applyStatusUpdate(currentTask, (TaskStatusUpdateEvent) event).block();
             } else if (event instanceof TaskArtifactUpdateEvent) {


### PR DESCRIPTION
When dealing with multi-level Flux connections with dependencies, concurrent execution is required to ensure the generated data can be returned as quickly as possible

## What's changed?

<!-- Describe Your PR Here -->


    @PostMapping(value = "/a2a/server4", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
    public Flux<JSONRPCResponse> dispatchStream4(JSONRPCRequest request) {
        Sinks.Many<JSONRPCResponse> sink2 = Sinks.many().multicast().onBackpressureBuffer();
        Mono<Void> mono = Mono.fromRunnable(() -> {
            log.info("xxx fromRunnable mono-1");
            sink2.tryEmitNext(createResponse("mono-1"));
        }).then(Mono.delay(Duration.ofMillis(1000))).then(Mono.fromRunnable(() -> {
            log.info("xxx fromRunnable mono-2");
            sink2.tryEmitNext(createResponse("mono-2"));
        })).then(Mono.delay(Duration.ofMillis(1000))).then(Mono.fromRunnable(() -> {
            log.info("xxx fromRunnable mono-3");
            sink2.tryEmitNext(createResponse("mono-3"));
        })).then(Mono.delay(Duration.ofMillis(1000))).then(Mono.fromRunnable(() -> {
            log.info("xxx fromRunnable mono complete");
            sink2.tryEmitComplete();
        })).then();
        Flux<JSONRPCResponse> flux2 = sink2.asFlux().timeout(Duration.ofSeconds(10));

        // option-wrong:
        //        return mono.thenMany(flux2)
        //                .doOnNext(event -> log.info("xxx doOnNext {}", event))
        //                .map(event -> {
        //                    log.info("xxx map {}", event);
        //                    return event;
        //                });

        // option-right
        return Flux.merge(mono.thenMany(Mono.empty()), flux2).doOnNext(event -> log.info("xxx doOnNext {}", event))
                .map(event -> {
                    log.info("xxx map {}", event);
                    return event;
                });
    }


The above code describes the returned two different results about the multiple flux which have dependency.

1. in "option-wrong" way

<img width="708" height="289" alt="image" src="https://github.com/user-attachments/assets/7a6d6a0f-45eb-492e-8482-f7ec422565f8" />

The data is returned in one time almost.

2. in "option-right" way

<img width="711" height="289" alt="image" src="https://github.com/user-attachments/assets/dacf747c-48c8-46bf-8c30-e205f3e36f05" />

The data is returned in time.

The data which is emitted by sink should be returned as quickly as possible, so use flux.merge instead of thenMany.

## Checklist

- [ ]  I have read the [Contributing Guide](https://github.com/a2ap/a2a4j/blob/main/CONTRIBUTING.md)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Any Else Note


