### PR TITLE
support FileContent deserialization

### DIFF
--- a/a2a4j-core/src/main/java/io/github/a2ap/core/model/FileContent.java
+++ b/a2a4j-core/src/main/java/io/github/a2ap/core/model/FileContent.java
@@ -18,6 +18,8 @@ package io.github.a2ap.core.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.Objects;
 
@@ -25,6 +27,14 @@ import java.util.Objects;
  * Represents the content of a file.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.DEDUCTION,
+        defaultImpl = FileContent.class
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(FileWithBytes.class),
+        @JsonSubTypes.Type(FileWithUri.class)
+})
 public abstract class FileContent {
 
     /**


### PR DESCRIPTION
## What's changed?

In a2a server request with file part could not be deserialized correctly.

here is the error message


```
11:06:43.197 [main] ERROR io.github.a2ap.core.client.impl.DefaultA2AClient - JSON-RPC error when sending message: code=-32602, message=Invalid params, data=Cannot construct instance of `io.github.a2ap.core.model.FileContent` (no Creators, like default constructor, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.github.a2ap.core.model.MessageSendParams["message"]->io.github.a2ap.core.model.Message["parts"]->java.util.ArrayList[0]->io.github.a2ap.core.model.FilePart["file"])
11:06:43.198 [main] ERROR io.github.a2ap.core.client.impl.DefaultA2AClient - Error sending message to system-cloud: Invalid params
```

This change includes annotations to support concrete FileContent subclasses.

## Checklist

- [ ]  I have read the [Contributing Guide](https://github.com/a2ap/a2a4j/blob/main/CONTRIBUTING.md)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Any Else Note


